### PR TITLE
Correct font color in mobile navigation menu

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -25,6 +25,10 @@ $brand-color: $orange;
     }
 }
 
+.trigger {
+    color: $text-color;
+}
+
 .site-nav .page-link {
     color: inherit;
 }


### PR DESCRIPTION
Correct font color in mobile navigation menu

Without this change, it the text is white on a white background :-(