### PR TITLE
Restore white color of navigation links

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -25,8 +25,10 @@ $brand-color: $orange;
     }
 }
 
-.trigger {
-    color: $text-color;
+@media screen and (max-width: 600px) {
+    .site-nav {
+        color: $text-color;
+    }
 }
 
 .site-nav .page-link {


### PR DESCRIPTION
#3 erroneously made the links always black.  This corrects the links to be white normally and black when on small screens (and thus in the menu).