### PR TITLE
Add link for editing on each page

### DIFF
--- a/_data/arduino-libraries.yml
+++ b/_data/arduino-libraries.yml
@@ -1,28 +1,35 @@
 - name: Arduino_Due_SD_HSCMI
   url: https://github.com/macchina/Arduino_Due_SD_HSMCI
   description: Gives access to HSMCI (High Speed MultiMedia Card Interface) on M2.
+
 - name: LIN
   url: https://github.com/macchina/LIN
   description: LIN bus functionality for M2 on 2 channels
+
 - name: SamNonDuePin
   url: https://github.com/macchina/SamNonDuePin
   description: Gives M2 access to "non-Due" pins.
+
 - name: SW_CAN
   url: https://github.com/macchina/Single-Wire-CAN
   description: Single-wire CAN (GMLAN) give M2 single-wire CAN functionality. Uses external MCP2515 transceiver connected to SAM3X via SPI. Library currently includes an example of sending SW CAN message.
+
 - name: ArduinoDUE_OBD_FreeRunningCAN
   url: https://github.com/macchina/ArduinoDUE_OBD_FreeRunningCAN
   description: Free-running CAN and OBDII data acquisition
+
 - name: OBD9141
   url: https://github.com/iwanders/OBD9141
   description: A class to read an ISO 9141-2 port found in OBD-II ports.
+
 - name: due_can
   url: https://github.com/collin80/due_can
   description: Object oriented canbus library for Arduino Due compatible boards
+
 - name: due_wire
   url: https://github.com/collin80/due_wire
   description: An alternative I2C library for Due with DMA support
+
 - name: M2_12VIO
   url: https://github.com/TDoust/M2_12VIO
   description: Provides 6x12V output drivers with over current protection for the output drivers and 6x12V analogue input circuits, plus support for the DUE on chip temperature.
-  

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,9 +1,11 @@
 - name: M2RET
   url: https://github.com/collin80/M2RET
   description: Reverse Engineering Tool running on Macchina M2 Hardware
+
 - name: SavvyCAN
   url: https://github.com/collin80/SavvyCAN
   description: QT-based cross platform CANbus tool.  May be used with data collected via the Macchina M2 interface board.
+
 - name: CanCat
   url: https://github.com/atlas0fd00m/CanCat
   description: Swiss army knife of Controller Area Networks (CAN) often used in cars and building automation that can run on the Macchina M2

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,46 @@
+<footer class="site-footer">
+
+  <div class="wrapper">
+
+    <h2 class="footer-heading">{{ site.title | escape }}</h2>
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col footer-col-1">
+        <ul class="contact-list">
+          <li>
+            {% if site.author %}
+              {{ site.author | escape }}
+            {% else %}
+              {{ site.title | escape }}
+            {% endif %}
+            </li>
+            {% if site.email %}
+            <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+            {% endif %}
+        </ul>
+      </div>
+
+      <div class="footer-col footer-col-2">
+        <ul class="social-media-list">
+          {% if site.github_username %}
+          <li>
+            {% include icon-github.html username=site.github_username %}
+          </li>
+          {% endif %}
+
+          {% if site.twitter_username %}
+          <li>
+            {% include icon-twitter.html username=site.twitter_username %}
+          </li>
+          {% endif %}
+        </ul>
+      </div>
+
+      <div class="footer-col footer-col-3">
+        <p>{{ site.description | escape }}</p>
+      </div>
+    </div>
+
+  </div>
+
+</footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,42 +5,34 @@
     <h2 class="footer-heading">{{ site.title | escape }}</h2>
 
     <div class="footer-col-wrapper">
+
       <div class="footer-col footer-col-1">
-        <ul class="contact-list">
-          <li>
-            {% if site.author %}
-              {{ site.author | escape }}
-            {% else %}
-              {{ site.title | escape }}
-            {% endif %}
-            </li>
-            {% if site.email %}
-            <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
-            {% endif %}
-        </ul>
+        <p>{{ site.description | escape }}</p>
       </div>
 
       <div class="footer-col footer-col-2">
-        <ul class="social-media-list">
-          {% if site.github_username %}
-          <li>
-            {% include icon-github.html username=site.github_username %}
-          </li>
-          {% endif %}
-
-          {% if site.twitter_username %}
-          <li>
-            {% include icon-twitter.html username=site.twitter_username %}
-          </li>
-          {% endif %}
-        </ul>
       </div>
 
       <div class="footer-col footer-col-3">
-        <p>{{ site.description | escape }}</p>
+        <ul class="contact-list">
+          <li>
+            {% if page.edit_path %}
+              {% assign path = page.edit_path %}
+            {% else %}
+              {% assign path = page.path %}
+            {% endif %}
+            <a href="https://github.com/macchina/showcase/edit/master/{{path}}"><span class="icon icon--github">{% include icon-github.svg %}</span><span>Edit this page on GitHub</span></a>
+          </li>
+          {% if site.email %}
+          <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+          {% endif %}
+        </ul>
+
+        <p>
+          This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+        </p>
       </div>
     </div>
-
   </div>
 
 </footer>

--- a/libraries.md
+++ b/libraries.md
@@ -1,5 +1,6 @@
 ---
 title: Libraries
+edit_path: _data/arduino-libraries.yml
 ---
 
 <!-- to add a library add it in _data/arduino-libraries.yml -->

--- a/projects.md
+++ b/projects.md
@@ -1,5 +1,6 @@
 ---
 title: Projects
+edit_path: _data/projects.yml
 ---
 
 <!-- to add a project add it in _data/projects.yml -->


### PR DESCRIPTION
Link is in footer and goes to either the YAML data file or the page itself depending on which is most applicable.

Once we have multiple sections on any of these pages, chances are good that we will have to make the link go to the page itself and users will be responsible for navigating to the correct list.